### PR TITLE
feat: isVerified for Github and Email

### DIFF
--- a/app/controller/account/binding.js
+++ b/app/controller/account/binding.js
@@ -257,7 +257,7 @@ class AccountBindingController extends Controller {
     // 邮箱账号验证密码
     const passwordHash = sha256(password).toString();
     if (platform === 'email' && userAccount.password_hash !== passwordHash) {
-      this.logger.error('controller.account.binding.changeMainAccount failed2', { password_hash: userAccount.password_hash, account, passwordHash, });
+      this.logger.error('controller.account.binding.changeMainAccount failed2', { password_hash: userAccount.password_hash, account, passwordHash });
       ctx.body = {
         ...ctx.msg.failure,
       };
@@ -289,6 +289,21 @@ class AccountBindingController extends Controller {
       data: result,
     };
   }
+
+  /**
+   * DAOJam 特色函数，详见：https://github.com/DAOJAM/DAO_Jam/issues/34
+   * 目前只检测是不是绑定 GitHub 和 邮箱 - Frank
+   * @memberof AccountBindingController
+   */
+  async isVerified() {
+    const { ctx } = this;
+    const result = await this.service.account.binding.isVerified(ctx.user.id);
+    ctx.body = {
+      ...ctx.msg.success,
+      data: result,
+    };
+  }
+
 }
 
 module.exports = AccountBindingController;

--- a/app/router.js
+++ b/app/router.js
@@ -437,6 +437,7 @@ module.exports = app => {
   router.post('/account/unbinding', passport.authorize, controller.account.binding.unbinding);
   router.post('/account/changeMainAccount', passport.authorize, controller.account.binding.changeMainAccount);
   router.get('/account/list', passport.authorize, controller.account.binding.list);
+  router.get('/account/isVerified', passport.authorize, controller.account.binding.isVerified);
 
   // router.post('/stablecoin/transfer', passport.verify, controller.ethereum.stablecoin.transfer);
 

--- a/app/service/account/binding.js
+++ b/app/service/account/binding.js
@@ -324,6 +324,22 @@ class AccountBindingService extends Service {
     }
     return errors.length > 0 ? errors : null;
   }
+
+  /**
+    * DAOJam 特色函数，详见：https://github.com/DAOJAM/DAO_Jam/issues/34
+    * 目前只检测是不是绑定 GitHub 和 邮箱 - Frank
+    * @param {number} uid DAOJam 用户 ID
+    */
+  async isVerified(uid) {
+    // 同时查询
+    const [ github, email ] = await Promise.all([
+      this.get(uid, 'github'),
+      this.get(uid, 'email'),
+    ]);
+    // 目前只检测是不是绑定 GitHub 和 邮箱，后续有需要再定制这个条件
+    const verified = Boolean(github && email);
+    return { verified };
+  }
 }
 
 module.exports = AccountBindingService;


### PR DESCRIPTION
<img width="998" alt="image" src="https://user-images.githubusercontent.com/3261732/77997360-db826800-7361-11ea-9224-7cf4995be57e.png">

# GET `/account/isVerified`
需要有用户的 access token 才可以访问
## 返回对象
`verified`： 如果同时绑定了 GitHub 和 Email 则为 true，否则为 false
## 例子 
```json
{
    "code": 0,
    "message": "成功",
    "data": {
        "verified": false
    }
}
```